### PR TITLE
Fix integration tests for usn-monitor action

### DIFF
--- a/actions/usn-monitor/entrypoint/main_test.go
+++ b/actions/usn-monitor/entrypoint/main_test.go
@@ -183,7 +183,7 @@ arbitrary code.
 						Description: "A NULL Pointer Dereference of CWE-476 exists in quassel version 0.12.4 in the quasselcore void CoreAuthHandler::handle(const Login &msg) coreauthhandler.cpp line 235 that allows an attacker to cause a denial of service.",
 					},
 				},
-				AffectedPackages: []string{"quassel-core", "quassel"},
+				AffectedPackages: []string{"quassel", "quassel-core"},
 			},
 			{
 				Title: "USN-4599-1: Firefox vulnerabilities",
@@ -294,7 +294,7 @@ arbitrary code.
 						Description: "A NULL Pointer Dereference of CWE-476 exists in quassel version 0.12.4 in the quasselcore void CoreAuthHandler::handle(const Login &msg) coreauthhandler.cpp line 235 that allows an attacker to cause a denial of service.",
 					},
 				},
-				AffectedPackages: []string{"quassel-core", "quassel"},
+				AffectedPackages: []string{"quassel", "quassel-core"},
 			},
 			{
 				Title: "USN-4499-1: MilkyTracker vulnerabilities",
@@ -465,7 +465,7 @@ arbitrary code.
 							Description: "",
 						},
 					},
-					AffectedPackages: []string{"quassel-core", "quassel"},
+					AffectedPackages: []string{"quassel", "quassel-core"},
 				},
 			}
 
@@ -493,7 +493,7 @@ arbitrary code.
 						Description: "A NULL Pointer Dereference of CWE-476 exists in quassel version 0.12.4 in the quasselcore void CoreAuthHandler::handle(const Login &msg) coreauthhandler.cpp line 235 that allows an attacker to cause a denial of service.",
 					},
 				},
-				AffectedPackages: []string{"quassel-core", "quassel"},
+				AffectedPackages: []string{"quassel", "quassel-core"},
 			}
 
 			content, err := ioutil.ReadFile(usnList.Name())


### PR DESCRIPTION
## Summary
The data we consume from [USNs page](https://ubuntu.com/security/notices/USN-4594-1) Is inconsistent. Since we parse the `rss` feed of the page, the exact order in which the affected packages appear on the web page matters as it affects our integration test.

We faced this issue [before](https://github.com/paketo-buildpacks/stack-usns/commit/9bb4df2584a80b80429e08689bfd9222297d9085) and looks like Ubuntu changed the order of the affected packages for `quassel` again.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
